### PR TITLE
fix(tsconfig): tsconfig paths should not be used for imports as NodeJ…

### DIFF
--- a/src/components/AddDocumentButton/AddDocumentButton.test.tsx
+++ b/src/components/AddDocumentButton/AddDocumentButton.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import AddDocumentButton from '~/components/AddDocumentButton/AddDocumentButton';
+import AddDocumentButton from './AddDocumentButton';
 import renderWithProviders from '~/tests/utils/withProviders';
 
 describe('<AddDocumentButton />', () => {

--- a/src/components/AddDocumentButton/AddDocumentButton.tsx
+++ b/src/components/AddDocumentButton/AddDocumentButton.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Button } from '@amsterdam/asc-ui';
 import Wizard, { ImplementationProps } from '../Wizard/Wizard';
-import CustomProvider from '~/store/CustomProvider';
+import CustomProvider from '../../store/CustomProvider';
 
 export type Props<T> = {
 	buttonText?: string;

--- a/src/components/Wizard/Wizard.tsx
+++ b/src/components/Wizard/Wizard.tsx
@@ -2,9 +2,9 @@ import React, { ReactNode, useEffect } from 'react';
 import { CustomFile, Modal, FileUploadProps } from '@amsterdam/bmi-component-library';
 import { Button } from '@amsterdam/asc-ui';
 import { ChevronLeft } from '@amsterdam/asc-assets';
-import { getFoo } from '~/store/selectors';
-import { init } from '~/store/actions';
-import { useDispatch, useSelector } from '~/store/CustomProvider';
+import { getFoo } from '../../store/selectors';
+import { init } from '../../store/actions';
+import { useDispatch, useSelector } from '../../store/CustomProvider';
 
 export type MetadataDataSubmitCallbackArg<T> = { metadata: T; file: CustomFile };
 export type CancelCallbackArg<T> = { metadata?: T; file?: CustomFile };

--- a/src/store/CustomProvider.tsx
+++ b/src/store/CustomProvider.tsx
@@ -6,7 +6,7 @@ import { composeWithDevTools } from 'redux-devtools-extension';
 import createSagaMiddleware from 'redux-saga';
 import * as dmsUploadReducers from './reducers';
 import { DEFAULT_STATE } from './reducers';
-import { IState } from '~/store/store';
+import { IState } from './store';
 
 const initialState: IState = {
 	dmsUpload: DEFAULT_STATE,

--- a/tests/utils/withProviders.tsx
+++ b/tests/utils/withProviders.tsx
@@ -3,7 +3,7 @@ import { RenderOptions, render } from '@testing-library/react';
 import { muiTheme } from '@amsterdam/bmi-component-library';
 import { GlobalStyle, ThemeProvider } from '@amsterdam/asc-ui';
 import { ThemeProvider as MUIThemeProvider } from '@material-ui/core/styles';
-import theme from '~/theme';
+import theme from '../../src/theme';
 
 function renderWithProviders(ui: React.ReactElement, options?: Omit<RenderOptions, 'queries'>) {
 	const AllTheProviders: React.FC = ({ children }) => (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
 		"baseUrl": ".",
 		"paths": {
 			"~/tests/*": ["tests/*"],
-			"~/*": ["src/*"]
 		},
 		"rootDir": "./",
 		"outDir": "./lib",


### PR DESCRIPTION
tsconfig paths should not be used for imports as NodeJS has no knowledge about them resulting in errors on the consumer end:
![image](https://user-images.githubusercontent.com/1095870/136233913-a9b9b6d7-83d5-410a-82a5-7d27c56b81ac.png)
