### PR TITLE
BDMS-4198: Datumveld is altijd verplicht, hoort niet zo te zijn

### DIFF
--- a/db.json
+++ b/db.json
@@ -161,7 +161,7 @@
         "id": 126,
         "placeholder": "Vertrouwelijkheid",
         "required": false,
-        "defaultValue": "0",
+        "defaultValue": "Openbaar",
         "userValue": null,
         "changeIndividual": false,
         "type": "ChoiceType",

--- a/src/components/BulkMetadataForm/BulkMetadataForm.test.tsx
+++ b/src/components/BulkMetadataForm/BulkMetadataForm.test.tsx
@@ -70,9 +70,9 @@ describe('<BulkMetadataForm />', () => {
 	});
 
 	test.each([
-		['default', 'carUse', 'bmi-isNotEmpty', "Geef de default waarde voor 'Gebruik auto' op"],
+		['default', 'carUse', 'bmi-isNotEmpty', "Geef de default waarde voor 'Gebruik auto' op "],
 		['custom', 'year', 'bmi-isNotEmpty', 'Jaartal mag niet leeg zijn (custom error message)'],
-		['default formatting', 'executionDate', 'format', "Het format voor 'Uitvoeringsdatum' is ongeldig"],
+		['default formatting', 'executionDate', 'format', "Het format voor 'Uitvoeringsdatum' is ongeldig "],
 	])('Should have %s error message', (testCase, property, errorType, errorMessage) => {
 		render();
 		const { schema } = mockComponentProps<ComponentProps<typeof Form>>(FormMock);

--- a/src/dms-integration/utils.ts
+++ b/src/dms-integration/utils.ts
@@ -17,7 +17,6 @@ export function convertDmsDynamicFormFieldsToMetadataProperty(fields: IDmsDynami
 		}
 
 		if (field.type === 'DateType') {
-			delete item.format;
 			item.oneOf = [{ format: 'date' }, { maxLength: 0 }];
 		}
 

--- a/src/dms-integration/utils.ts
+++ b/src/dms-integration/utils.ts
@@ -9,6 +9,7 @@ export function convertDmsDynamicFormFieldsToMetadataProperty(fields: IDmsDynami
 			scope: 'string',
 			type: 'string',
 			label: field.placeholder,
+			options: { format: undefined },
 		};
 
 		if (field.required) {
@@ -16,7 +17,8 @@ export function convertDmsDynamicFormFieldsToMetadataProperty(fields: IDmsDynami
 		}
 
 		if (field.type === 'DateType') {
-			item.format = 'date';
+			delete item.format;
+			item.oneOf = [{ format: 'date' }, { maxLength: 0 }];
 		}
 
 		if (field.type === 'ChoiceType') {

--- a/src/types/MetadataPropertyType.ts
+++ b/src/types/MetadataPropertyType.ts
@@ -6,6 +6,9 @@ export type MetadataProperty = {
 	label: string;
 	'bmi-isNotEmpty'?: boolean;
 	'bmi-errorMessage'?: string;
-	oneOf?: { const: string; title: string }[];
+	oneOf?: { const: string; title: string }[] | OneOfDateType;
 	customFormat?: 'creatable';
+	options?: { format?: string };
 };
+
+export type OneOfDateType = Array<{ maxLength: number } | { format: string }>;

--- a/src/utils/createSchemaFromMetadataProps.test.ts
+++ b/src/utils/createSchemaFromMetadataProps.test.ts
@@ -16,8 +16,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						value: {
 							'bmi-isNotEmpty': true,
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Gebruik auto' op",
-								format: "Het format voor 'Gebruik auto' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Gebruik auto' op ",
+								format: "Het format voor 'Gebruik auto' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -35,8 +35,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						value: {
 							'bmi-isNotEmpty': true,
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Contract' op",
-								format: "Het format voor 'Contract' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Contract' op ",
+								format: "Het format voor 'Contract' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -54,8 +54,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						value: {
 							'bmi-isNotEmpty': true,
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Document omschrijving' op",
-								format: "Het format voor 'Document omschrijving' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Document omschrijving' op ",
+								format: "Het format voor 'Document omschrijving' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -72,8 +72,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Ingenieursbureau' op",
-								format: "Het format voor 'Ingenieursbureau' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Ingenieursbureau' op ",
+								format: "Het format voor 'Ingenieursbureau' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -90,8 +90,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Uitvoeringsdatum' op",
-								format: "Het format voor 'Uitvoeringsdatum' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Uitvoeringsdatum' op ",
+								format: "Het format voor 'Uitvoeringsdatum' is ongeldig ",
 							},
 							format: 'date',
 							type: 'string',
@@ -109,8 +109,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'ILS-2' op",
-								format: "Het format voor 'ILS-2' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'ILS-2' op ",
+								format: "Het format voor 'ILS-2' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -127,8 +127,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'ILS-3' op",
-								format: "Het format voor 'ILS-3' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'ILS-3' op ",
+								format: "Het format voor 'ILS-3' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -145,8 +145,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Monitoring' op",
-								format: "Het format voor 'Monitoring' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Monitoring' op ",
+								format: "Het format voor 'Monitoring' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -164,8 +164,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						value: {
 							customFormat: 'creatable',
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Object type' op",
-								format: "Het format voor 'Object type' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Object type' op ",
+								format: "Het format voor 'Object type' is ongeldig ",
 							},
 							oneOf: [
 								{
@@ -196,8 +196,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Herhalingsmeter' op",
-								format: "Het format voor 'Herhalingsmeter' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Herhalingsmeter' op ",
+								format: "Het format voor 'Herhalingsmeter' is ongeldig ",
 							},
 							type: 'string',
 						},
@@ -214,8 +214,8 @@ describe('utils/createSchemaFromMetadataProps', () => {
 						},
 						value: {
 							errorMessage: {
-								'bmi-isNotEmpty': "Geef de default waarde voor 'Bron' op",
-								format: "Het format voor 'Bron' is ongeldig",
+								'bmi-isNotEmpty': "Geef de default waarde voor 'Bron' op ",
+								format: "Het format voor 'Bron' is ongeldig ",
 							},
 							type: 'string',
 						},

--- a/src/utils/createSchemaFromMetadataProps.ts
+++ b/src/utils/createSchemaFromMetadataProps.ts
@@ -30,8 +30,8 @@ export default function createSchemaFromMetadataProps(
 						value: {
 							type,
 							errorMessage: {
-								format: customErrorMessage ?? `Het format voor '${label}' is ongeldig`,
-								'bmi-isNotEmpty': customErrorMessage ?? `Geef de default waarde voor '${label}' op`,
+								format: customErrorMessage ?? `Het format voor '${label}' is ongeldig `,
+								'bmi-isNotEmpty': customErrorMessage ?? `Geef de default waarde voor '${label}' op `,
 							},
 						},
 					},

--- a/src/utils/createUISchemaFromMetadataProps.test.ts
+++ b/src/utils/createUISchemaFromMetadataProps.test.ts
@@ -11,6 +11,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Jaar',
 							scope: '#/properties/year/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -26,6 +29,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Document omschrijving',
 							scope: '#/properties/documentDescription/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -41,6 +47,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Contract',
 							scope: '#/properties/contract/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -56,6 +65,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Gebruik auto',
 							scope: '#/properties/carUse/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -71,6 +83,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Herhalingsmeter',
 							scope: '#/properties/repetitionMeter/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -86,6 +101,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'ILS-3',
 							scope: '#/properties/ils3/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -101,6 +119,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Monitoring',
 							scope: '#/properties/monitoring/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -116,6 +137,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Object type',
 							scope: '#/properties/objectType/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -131,6 +155,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Uitvoeringsdatum',
 							scope: '#/properties/executionDate/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -146,6 +173,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Bron',
 							scope: '#/properties/source/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -161,6 +191,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'Ingenieursbureau',
 							scope: '#/properties/engineeringOffice/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,
@@ -176,6 +209,9 @@ describe('utils/createUISchemaFromMetadataProps', () => {
 							label: 'ILS-2',
 							scope: '#/properties/ils2/properties/value',
 							type: 'Control',
+							options: {
+								format: undefined,
+							},
 						},
 						{
 							label: false,

--- a/src/utils/createUISchemaFromMetadataProps.ts
+++ b/src/utils/createUISchemaFromMetadataProps.ts
@@ -1,15 +1,20 @@
-import { MetadataProperty } from '../types';
+import { MetadataProperty, OneOfDateType } from '../types';
 
 export default function createUISchemaFromMetadataProps(metadataProperties: MetadataProperty[]) {
+	console.log('metadataProperties:: ', metadataProperties);
 	return {
 		type: 'Group',
-		elements: metadataProperties.map(({ key, scope, label }): any => ({
+		elements: metadataProperties.map(({ key, scope, label, oneOf }): any => ({
 			type: 'HorizontalLayout',
 			elements: [
 				{
 					type: 'Control',
 					label,
 					scope: `#/properties/${key}/properties/value`,
+					options: {
+						// @ts-ignore: tech debt, should be revised
+						format: oneOf?.find((oo: OneOfDateType) => oo?.format)?.format,
+					},
 				},
 				{
 					type: 'Control',

--- a/src/utils/createUISchemaFromMetadataProps.ts
+++ b/src/utils/createUISchemaFromMetadataProps.ts
@@ -1,7 +1,6 @@
 import { MetadataProperty, OneOfDateType } from '../types';
 
 export default function createUISchemaFromMetadataProps(metadataProperties: MetadataProperty[]) {
-	console.log('metadataProperties:: ', metadataProperties);
 	return {
 		type: 'Group',
 		elements: metadataProperties.map(({ key, scope, label, oneOf }): any => ({


### PR DESCRIPTION
- Date now also accepts empty values