### PR TITLE
BDMS-4738: Metadata van checkbox is niet zichtbaar in overview

### DIFF
--- a/src/features/bulk/FileViewer/DefaultFieldsTable/DefaultFieldsTable.tsx
+++ b/src/features/bulk/FileViewer/DefaultFieldsTable/DefaultFieldsTable.tsx
@@ -14,7 +14,7 @@ export default function DefaultFieldsTable({ fields }: Props) {
 			{fields &&
 				fields.map((field) => (
 					<StyledDescriptionListItem term={field.label} key={field.id}>
-						{field.value}
+						{field.value === true ? '✔' : field.type === 'multi-select' ? field.value + '' : field.value}
 					</StyledDescriptionListItem>
 				))}
 		</DescriptionList>


### PR DESCRIPTION
- boolean TRUE returned an empty string, multi-select had no seperators
- Also fixes BDMS-4641