### PR TITLE
Feature/single file upload steps

### DIFF
--- a/docs/Documentation_NL.md
+++ b/docs/Documentation_NL.md
@@ -11,13 +11,14 @@
 DMS Upload kent twee uitvoeringen, een single-file en een bulk upload. In de single-file modus kan je een bestand uploaden en deze voorzien van metadata. In de bulk modus kan je meerdere bestanden uploaden en deze voorzien van algemene metadata en individuele metadata per bestand.
 
 ---
+
 ## Technical Depth
 
 ### CreatableSelect/CreatableSelectArray
 
-Er is een stuk technical depth rondom het selectbox element. Voor de bulk-upload wordt een nieuwe variant `<CreatableSelectArray />` gebruikt. Voor single-upload gebruiken we de het oude component;  `<CreatableSelect />`. De Technical depth zit in een stuk duplicatie tussen de twee componenten, al werken ze wel op een andere manier. 
+Er is een stuk technical depth rondom het selectbox element. Voor de bulk-upload wordt een nieuwe variant `<CreatableSelectArray />` gebruikt. Voor single-upload gebruiken we de het oude component; `<CreatableSelect />`. De Technical depth zit in een stuk duplicatie tussen de twee componenten, al werken ze wel op een andere manier.
 
-Het voornemen is om deze componenten later te repareren en volgens een oplossing te laten werken. De reden voor het opnemen van deze technical depth is omdat we in tijdsnoods kwamen rondom de oplevering van DMS. Het oplossen van de bugs rondom validatie in het selectbox element lukte niet met het oude component `<CreatableSelect />`. 
+Het voornemen is om deze componenten later te repareren en volgens een oplossing te laten werken. De reden voor het opnemen van deze technical depth is omdat we in tijdsnoods kwamen rondom de oplevering van DMS. Het oplossen van de bugs rondom validatie in het selectbox element lukte niet met het oude component `<CreatableSelect />`.
 
 ### CreatableSelect
 
@@ -28,14 +29,16 @@ Dit is het oude component wat in single-upload wordt gebruikt. Deze werkt met ee
 Dit is het nieuwe component wat in bulk-upload wordt gebruikt. Deze werkt met een array van enums voor het generen van de opties.
 
 ---
-## Interfaces 
+
+## Interfaces
+
 ### Algemeen
 
-De interfaces voor `<Single />` en `<Bulk  />` zijn grotendeels gelijk.
+De interfaces voor `<Single />` en `<Bulk />` zijn grotendeels gelijk.
 
 ```
 asset               - Asset object
-basePath            - Pad dat vanuit DMS wordt meegegeven 
+basePath            - Pad dat vanuit DMS wordt meegegeven
                       (bijv `/documents/29/bulk-metadata`)
 getHeaders          - Callback voor request headers
 getPostUrl          - Callback voor opvragen POST url
@@ -66,6 +69,7 @@ onMetadataSubmit    - Callback voor opslaan metadata
 ```
 
 ---
+
 ## Structuur
 
 De props aan `<Single />` en `<Bulk />` worden doorgegeven aan `<StepX />` en `<SingleWizard />`, `<BulkWizard />`.
@@ -106,6 +110,7 @@ De props aan `<Single />` en `<Bulk />` worden doorgegeven aan `<StepX />` en `<
 #### Step 1
 
 Beheert de state vanuit het `<FileUpload />` component. En roept de callbacks aan die vanuit de `Props` komen, meegegeven vanuit `<Bulk />`.
+In Step1 wordt de state bepaald of het om een single of bulk modus gaat, middels de `isBulkMode` property. Single wordt onderliggend afgehandeld als een bulk, maar slaat in de UI een stap over en gaat gelijk naar stap 3, waarbij alle fields editable zijn.
 
 **FileUpload**
 
@@ -127,14 +132,15 @@ Beheert de state vanuit de `<Pagination />` en `<FileViewer />` componenten. En 
 
 Toont de individuele velden, standaard velden en een voorvertoning van het bestand.
 
-* `<IndividualFieldsForm />` toont de velden die individueel per bestand moeten worden aangepast.
-* `<DefaultFieldsTable />` toont de velden die standaard zijn voor alle bestanden
-* `<DocumentViewer />` toont de voorvertoning van het bestand.
+- `<IndividualFieldsForm />` toont de velden die individueel per bestand moeten worden aangepast.
+- `<DefaultFieldsTable />` toont de velden die standaard zijn voor alle bestanden
+- `<DocumentViewer />` toont de voorvertoning van het bestand.
 
 ---
+
 ## State (Redux)
 
-Zie `src/features/single/single/store/slice.ts` en `src/features/bulk/bulk/store/slice.ts` voor de slices. 
+Zie `src/features/single/single/store/slice.ts` en `src/features/bulk/bulk/store/slice.ts` voor de slices.
 
 Zie `src/features/single/single/store/model.ts` en `src/features/bulk/bulk/store/model.ts` voor de Interfaces van de twee stores.
 
@@ -148,9 +154,11 @@ state:
     - currentStep
 	- files
 	- fields
+	- isBulkMode
 ```
 
 ---
+
 ## Data conversie
 
 ### Bulk
@@ -158,18 +166,19 @@ state:
 Er vinden een aantal data conversies plaats.
 
 1. DMS velden naar de state.bulk.fields.
-	`convertDmsDynamicFormFieldsToBulkMetadataFields`
+   `convertDmsDynamicFormFieldsToBulkMetadataFields`
 2. DMS velden omvormen voor metadataProperties, nodig JSONForms schema en uischema
-	`convertDmsDynamicFormFieldsToMetadataProperty`
+   `convertDmsDynamicFormFieldsToMetadataProperty`
 3. state.bulk.fields omvormen voor metadataProperties, nodig JSONForms schema en uischema
-	`convertBulkFieldsToMetadataProperties`
+   `convertBulkFieldsToMetadataProperties`
 4. state.bulk.fields naar JSONForms data
-	`convertBulkFieldsToMetadataGenericTypes`
+   `convertBulkFieldsToMetadataGenericTypes`
 
 Er vind dus een conversie plaats in `App.tsx` zodat de data vanuit DMS wordt omgezet naar objecten die nodig zijn voor JSONForms en de velden in de state.
-Ook is er een belangrijke conversie in `<FileViewer />`, daar wordt de state omgezet naar objecten die nodig zijn voor JSONForms. 
+Ook is er een belangrijke conversie in `<FileViewer />`, daar wordt de state omgezet naar objecten die nodig zijn voor JSONForms.
 
 --
+
 ## Mock API
 
 In `db.json` wordt de mock-api beschreven, deze json is de input voor de [json-server](https://github.com/typicode/json-server) module.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@amsterdam/bmi-dms-upload",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "description": "A document upload flow that can be implemented in any BMI React application. Documents are stored in DMS. Metadata can be added in the flow.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/dms-integration/utils.ts
+++ b/src/dms-integration/utils.ts
@@ -17,7 +17,7 @@ export function convertDmsDynamicFormFieldsToMetadataProperty(fields: IDmsDynami
 		}
 
 		if (field.type === 'CheckboxType') {
-			item.type = "boolean"
+			item.type = 'boolean';
 		}
 
 		if (field.type === 'DateType') {
@@ -52,7 +52,7 @@ export function convertDmsDynamicFormFieldsToMetadataProperty(fields: IDmsDynami
 			if (field.defaultValue) {
 				item.default = JSON.parse(field.defaultValue);
 			} else {
-				item.default = []
+				item.default = [];
 			}
 		}
 
@@ -66,10 +66,10 @@ export function convertDmsDynamicFormFieldsToBulkMetadataFields(fields: IDmsDyna
 		let newValue: IBulkField['value'] = defaultValue;
 
 		if (convertDmsTypeToBulkFieldType(field.type) === 'select') {
-			newValue = defaultValue ? JSON.parse(`["${defaultValue}"]`): [];
+			newValue = defaultValue ? JSON.parse(`["${defaultValue}"]`) : [];
 		}
 		if (convertDmsTypeToBulkFieldType(field.type) === 'multi-select') {
-			newValue = defaultValue ? JSON.parse(defaultValue): [];
+			newValue = defaultValue ? JSON.parse(defaultValue) : [];
 		}
 
 		if (convertDmsTypeToBulkFieldType(field.type) === 'checkbox') {

--- a/src/features/bulk/bulk/Bulk.test.tsx
+++ b/src/features/bulk/bulk/Bulk.test.tsx
@@ -3,7 +3,7 @@ import { screen, fireEvent, act } from '@testing-library/react';
 import { render } from '../../../tests/utils/testUtils';
 import { MetadataExample } from '../../../types';
 import { asset, data as mockData, schema, uischema, files as filesMock, fields as fieldsMock } from './__stubs__';
-import { Props } from './types';
+import { BulkUploadProps } from './types';
 import { CurrentStep } from './store/model';
 import { BulkStepsToRoutes } from './constants';
 import { Bulk } from './Bulk';
@@ -18,7 +18,7 @@ import {
 	onMetadataSubmitMock,
 } from './__mocks__/bulk';
 
-const defaultProps: Props<MetadataExample> = {
+const defaultProps: BulkUploadProps<MetadataExample> = {
 	asset: asset,
 	getDocumentViewUrl: getDocumentViewUrlMock,
 	getPostUrl: getPostUrlMock,

--- a/src/features/bulk/bulk/Bulk.tsx
+++ b/src/features/bulk/bulk/Bulk.tsx
@@ -7,14 +7,14 @@ import Step1 from '../steps/Step1';
 import Step2 from '../steps/Step2';
 import Step3 from '../steps/Step3';
 
-import { Props } from './types';
+import { BulkUploadProps } from './types';
 import { useRouteDetect } from './hooks/useRouteDetect';
 import { useDispatch } from 'react-redux';
 import { setBasePath } from '../../single/single/store/slice';
 
 const NoRoute = () => <></>;
 
-export function Bulk<T>(props: Props<T>) {
+export function Bulk<T>(props: BulkUploadProps<T>) {
 	const dispatch = useDispatch();
 	useRouteDetect(props?.basePath ?? '/');
 

--- a/src/features/bulk/bulk/__stubs__/index.ts
+++ b/src/features/bulk/bulk/__stubs__/index.ts
@@ -4,3 +4,4 @@ export * from './metadataFields';
 export * from './schema';
 export * from './state';
 export * from './uischema';
+export * from './props';

--- a/src/features/bulk/bulk/__stubs__/props.ts
+++ b/src/features/bulk/bulk/__stubs__/props.ts
@@ -1,0 +1,35 @@
+import { asset } from './asset';
+import { mockData } from './data';
+import { schema } from './schema';
+import { uischema } from './uischema';
+
+import {
+	getPostUrlMock,
+	getHeadersMock,
+	getDocumentViewUrlMock,
+	onFileSuccessMock,
+	onFileRemoveMock,
+	onChangeMock,
+	onMetadataSubmitMock,
+	onCancelMock,
+} from '../__mocks__/bulk';
+
+export const defaultProps = {
+	asset: asset,
+	getPostUrl: getPostUrlMock,
+	getHeaders: getHeadersMock,
+	getDocumentViewUrl: getDocumentViewUrlMock,
+	onFileSuccess: onFileSuccessMock,
+	onFileRemove: onFileRemoveMock,
+	metadataForm: {
+		schema,
+		uischema,
+		data: mockData,
+		onChange: onChangeMock,
+		renderers: [],
+	},
+	onMetadataSubmit: onMetadataSubmitMock,
+	onCancel: onCancelMock,
+	basePath: '/',
+	isValidForm: false,
+};

--- a/src/features/bulk/bulk/__stubs__/state.ts
+++ b/src/features/bulk/bulk/__stubs__/state.ts
@@ -58,4 +58,5 @@ export const state: IBulkState = {
 	currentStep: 0,
 	fields,
 	files,
+	isBulkMode: true,
 };

--- a/src/features/bulk/bulk/store/model.ts
+++ b/src/features/bulk/bulk/store/model.ts
@@ -40,6 +40,7 @@ export interface IBulkState {
 	files: IBulkFile[];
 	fields: IBulkField[];
 	selectedFileId?: IBulkFieldId;
+	isBulkMode: boolean;
 }
 
 export interface IFieldData {

--- a/src/features/bulk/bulk/store/model.ts
+++ b/src/features/bulk/bulk/store/model.ts
@@ -39,7 +39,6 @@ export interface IBulkState {
 	currentStep: CurrentStep;
 	files: IBulkFile[];
 	fields: IBulkField[];
-	selectedFileId?: IBulkFieldId;
 	isBulkMode: boolean;
 }
 

--- a/src/features/bulk/bulk/store/sagas.ts
+++ b/src/features/bulk/bulk/store/sagas.ts
@@ -17,10 +17,10 @@ interface ActionType {
 	};
 }
 
-function* back(action: ActionType) {
+function* back({ payload }: ActionType) {
 	const currentStep: CurrentStep = yield select(getCurrentStep);
-	const { navigate } = action.payload;
 	const basePath: string = yield select(getBasePath);
+	const { navigate } = payload;
 
 	switch (currentStep) {
 		case CurrentStep.EditFields:
@@ -35,16 +35,18 @@ function* back(action: ActionType) {
 	}
 }
 
-function* forward(action: ActionType) {
+function* forward({ payload }: ActionType) {
 	const currentStep: CurrentStep = yield select(getCurrentStep);
-	const files: CustomFileLight | undefined = yield select(getFiles);
-
-	const { navigate } = action.payload;
 	const basePath: string = yield select(getBasePath);
+	const files: CustomFileLight[] | undefined = yield select(getFiles);
+	const { navigate } = payload;
 
 	switch (currentStep) {
 		case CurrentStep.Upload:
-			if (files) navigate(buildPath(basePath, BulkStepsToRoutes[CurrentStep.SelectFields]));
+			if (files) {
+				const nextStep = files.length > 1 ? CurrentStep.SelectFields : CurrentStep.EditFields;
+				navigate(buildPath(basePath, BulkStepsToRoutes[nextStep]));
+			}
 			break;
 		case CurrentStep.SelectFields:
 			navigate(buildPath(basePath, BulkStepsToRoutes[CurrentStep.EditFields]));
@@ -54,8 +56,8 @@ function* forward(action: ActionType) {
 
 /* eslint-disable require-yield */
 function* resetRoute(action: ActionType) {
-	const { navigate } = action.payload;
 	const basePath: string = yield select(getBasePath);
+	const { navigate } = action.payload;
 	navigate(buildPath(basePath, BulkStepsToRoutes[0]));
 }
 

--- a/src/features/bulk/bulk/store/selectors.ts
+++ b/src/features/bulk/bulk/store/selectors.ts
@@ -34,3 +34,5 @@ export const getChangeIndividualFields = createSelector([getFields], (fields): I
 export const getDefaultFields = createSelector([getFields], (fields): IBulkField[] =>
 	fields.filter((field) => !field.changeIndividual),
 );
+
+export const getIsBulkMode = createSelector(getState, (state: IBulkState) => state.isBulkMode);

--- a/src/features/bulk/bulk/store/slice.test.ts
+++ b/src/features/bulk/bulk/store/slice.test.ts
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 
 import { CustomFileLightOrRejection } from '../../../../types';
 import { files as filesMock, fields as fieldsMock, state as stateMock } from '../__stubs__';
+import { CurrentStep, IBulkField, IBulkFile, IBulkFileMetadata } from './model';
 import {
 	reducer,
 	initialState,
@@ -12,8 +13,10 @@ import {
 	removeFile,
 	setFileMetadata,
 	setBasePath,
+	setAllFieldsEditable,
+	resetFieldsAndFiles,
+	setBulkMode,
 } from './slice';
-import { CurrentStep, IBulkFileMetadata } from './model';
 
 jest.mock('react-router-dom-v5-compat');
 
@@ -85,5 +88,65 @@ describe('Bulk Slice', () => {
 		expect(reducer(stateMock, setFileMetadata({ fileId: '1', metadata: [newValues] })).files[0].metadata).toStrictEqual(
 			[newValues],
 		);
+	});
+
+	test('setAllFieldsEditable', () => {
+		const metadataFields = [
+			{ id: '1', changeIndividual: false },
+			{ id: '3', changeIndividual: false },
+		] as IBulkField[];
+
+		const result = reducer(initialState, setAllFieldsEditable(metadataFields)).fields;
+		const expectedResult = [
+			{ id: '1', changeIndividual: true },
+			{ id: '3', changeIndividual: true },
+		] as IBulkField[];
+
+		expect(result).toStrictEqual(expectedResult);
+	});
+
+	test('resetFieldsAndFiles', () => {
+		const fields = [
+			{ id: '1', changeIndividual: true },
+			{ id: '3', changeIndividual: true },
+		] as IBulkField[];
+		const files = [
+			{
+				id: '1',
+				uploadedFile: {},
+				metadata: [] as IBulkFileMetadata[],
+			},
+			{
+				id: '2',
+				uploadedFile: {},
+				metadata: [] as IBulkFileMetadata[],
+			},
+		] as IBulkFile[];
+		const mockState = { ...initialState, files, fields };
+
+		const result = reducer(mockState, resetFieldsAndFiles());
+		const expectedFields = [
+			{ id: '1', changeIndividual: false },
+			{ id: '3', changeIndividual: false },
+		];
+		const expectedFiles = [
+			{
+				id: '1',
+				uploadedFile: {},
+			},
+			{
+				id: '2',
+				uploadedFile: {},
+			},
+		];
+
+		expect(result.fields).toStrictEqual(expectedFields);
+		expect(result.files).toStrictEqual(expectedFiles);
+	});
+
+	test('setBulkMode', () => {
+		const result = reducer(initialState, setBulkMode(true));
+
+		expect(result.isBulkMode).toBeTruthy();
 	});
 });

--- a/src/features/bulk/bulk/store/slice.ts
+++ b/src/features/bulk/bulk/store/slice.ts
@@ -19,39 +19,42 @@ export const slice = createSlice({
 		setBasePath: (state: IBulkState, action: PayloadAction<string>) => {
 			state.basePath = action.payload;
 		},
-		removeFile: (state: IBulkState, action: PayloadAction<CustomFileLightOrRejection>) => {
-			state.files = state.files.filter((file) => file.uploadedFile.tmpId !== action.payload.tmpId);
+		removeFile: (state: IBulkState, { payload }: PayloadAction<CustomFileLightOrRejection>) => {
+			state.files = state.files.filter((file) => file.uploadedFile.tmpId !== payload.tmpId);
 		},
 		resetState: (state: IBulkState, action: PayloadAction<{ navigate: NavigateFunction }>) => initialState,
-		setCurrentStep: (state: IBulkState, action: PayloadAction<CurrentStep>) => {
-			state.currentStep = action.payload;
+		setCurrentStep: (state: IBulkState, { payload }: PayloadAction<CurrentStep>) => {
+			state.currentStep = payload;
 		},
-		setFields: (state: IBulkState, action: PayloadAction<IBulkField[]>) => {
-			state.fields = action.payload;
+		setFields: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
+			state.fields = payload;
 		},
-		setFile: (state: IBulkState, action: PayloadAction<IBulkFile>) => {
-			state.files = [...state.files, action.payload];
+		setAllFieldsEditable: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
+			state.fields = payload.map((field) => ({ ...field, changeIndividual: true }));
+		},
+		setFile: (state: IBulkState, { payload }: PayloadAction<IBulkFile>) => {
+			state.files = [...state.files, payload];
 		},
 		setFileMetadata: (
 			state: IBulkState,
-			action: PayloadAction<{ fileId: IBulkFile['id']; metadata: IBulkFile['metadata'] }>,
+			{ payload }: PayloadAction<{ fileId: IBulkFile['id']; metadata: IBulkFile['metadata'] }>,
 		) => {
-			const file = state.files.find((file) => file.id === action.payload.fileId);
+			const file = state.files.find((file) => file.id === payload.fileId);
 			if (!file) return;
-			file.metadata = action.payload.metadata;
+			file.metadata = payload.metadata;
 		},
 		setFileMetadataValidity: (
 			state: IBulkState,
-			action: PayloadAction<{ fileId: IBulkFile['id']; isValid: IBulkFile['isMetadataValid'] }>,
+			{ payload }: PayloadAction<{ fileId: IBulkFile['id']; isValid: IBulkFile['isMetadataValid'] }>,
 		) => {
-			const file = state.files.find((file) => file.id === action.payload.fileId);
+			const file = state.files.find((file) => file.id === payload.fileId);
 			if (!file) return;
-			file.isMetadataValid = action.payload.isValid;
+			file.isMetadataValid = payload.isValid;
 		},
 		stepBack: (state: IBulkState, action: PayloadAction<{ navigate: NavigateFunction }>) => state,
 		stepForward: (state: IBulkState, action: PayloadAction<{ navigate: NavigateFunction }>) => state,
-		setBulkMode: (state: IBulkState, action: PayloadAction<boolean>) => {
-			state.isBulkMode = action.payload;
+		setBulkMode: (state: IBulkState, { payload }: PayloadAction<boolean>) => {
+			state.isBulkMode = payload;
 		},
 	},
 });
@@ -68,6 +71,7 @@ export const {
 	stepBack,
 	stepForward,
 	setBulkMode,
+	setAllFieldsEditable,
 } = slice.actions;
 
 export const { reducer } = slice;

--- a/src/features/bulk/bulk/store/slice.ts
+++ b/src/features/bulk/bulk/store/slice.ts
@@ -32,8 +32,8 @@ export const slice = createSlice({
 		setAllFieldsEditable: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
 			state.fields = payload.map((field) => ({ ...field, changeIndividual: true }));
 		},
-		resetFieldsAndFiles: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
-			state.fields = payload.map((field) => ({ ...field, changeIndividual: false }));
+		resetFieldsAndFiles: (state: IBulkState, action: PayloadAction) => {
+			state.fields = state.fields.map((field) => ({ ...field, changeIndividual: false }));
 
 			// Reset file data to initial state, which only has the id and uploadedFile properties
 			if (state.files && state.files.length) {

--- a/src/features/bulk/bulk/store/slice.ts
+++ b/src/features/bulk/bulk/store/slice.ts
@@ -9,6 +9,7 @@ export const initialState: IBulkState = {
 	currentStep: CurrentStep.Button,
 	files: [],
 	fields: [],
+	isBulkMode: true,
 };
 
 export const slice = createSlice({
@@ -49,6 +50,9 @@ export const slice = createSlice({
 		},
 		stepBack: (state: IBulkState, action: PayloadAction<{ navigate: NavigateFunction }>) => state,
 		stepForward: (state: IBulkState, action: PayloadAction<{ navigate: NavigateFunction }>) => state,
+		setBulkMode: (state: IBulkState, action: PayloadAction<boolean>) => {
+			state.isBulkMode = action.payload;
+		},
 	},
 });
 
@@ -63,6 +67,7 @@ export const {
 	setFileMetadataValidity,
 	stepBack,
 	stepForward,
+	setBulkMode,
 } = slice.actions;
 
 export const { reducer } = slice;

--- a/src/features/bulk/bulk/store/slice.ts
+++ b/src/features/bulk/bulk/store/slice.ts
@@ -35,6 +35,7 @@ export const slice = createSlice({
 		resetFieldsAndFiles: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
 			state.fields = payload.map((field) => ({ ...field, changeIndividual: false }));
 
+			// Reset file data to initial state, which only has the id and uploadedFile properties
 			if (state.files && state.files.length) {
 				const defaultFiles = state.files.map(({ id, uploadedFile }) => ({ id, uploadedFile }));
 

--- a/src/features/bulk/bulk/store/slice.ts
+++ b/src/features/bulk/bulk/store/slice.ts
@@ -32,6 +32,15 @@ export const slice = createSlice({
 		setAllFieldsEditable: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
 			state.fields = payload.map((field) => ({ ...field, changeIndividual: true }));
 		},
+		resetFieldsAndFiles: (state: IBulkState, { payload }: PayloadAction<IBulkField[]>) => {
+			state.fields = payload.map((field) => ({ ...field, changeIndividual: false }));
+
+			if (state.files && state.files.length) {
+				const defaultFiles = state.files.map(({ id, uploadedFile }) => ({ id, uploadedFile }));
+
+				state.files = defaultFiles;
+			}
+		},
 		setFile: (state: IBulkState, { payload }: PayloadAction<IBulkFile>) => {
 			state.files = [...state.files, payload];
 		},
@@ -72,6 +81,7 @@ export const {
 	stepForward,
 	setBulkMode,
 	setAllFieldsEditable,
+	resetFieldsAndFiles,
 } = slice.actions;
 
 export const { reducer } = slice;

--- a/src/features/bulk/bulk/types.ts
+++ b/src/features/bulk/bulk/types.ts
@@ -4,7 +4,7 @@ import { CustomFileLight } from '../../../types';
 
 export type TGetDocumentViewUrl = (id: string) => Promise<string>;
 
-export interface Props<T> extends Omit<SingleProps<T>, 'onMetadataSubmit'> {
+export interface BulkUploadProps<T> extends Omit<SingleProps<T>, 'onMetadataSubmit'> {
 	onMetadataSubmit: (data: IBulkFile[]) => Promise<void>;
 	getDocumentViewUrl: TGetDocumentViewUrl;
 	metadataFields?: IBulkField[];

--- a/src/features/bulk/steps/Step1.test.tsx
+++ b/src/features/bulk/steps/Step1.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-redux', () => ({
 	useDispatch: jest.fn().mockReturnValue(jest.fn()),
 }));
 
-describe.only('<Step1 />', () => {
+describe('<Step1 />', () => {
 	test('should render component', () => {
 		const store = {
 			bulk: state,

--- a/src/features/bulk/steps/Step1.test.tsx
+++ b/src/features/bulk/steps/Step1.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+import Step1 from './Step1';
+import * as SliceModule from '../bulk/store/slice';
+
+import { render } from '../../../tests/utils/testUtils';
+import { files, state } from '../bulk/__stubs__/state';
+import { metadataFields, defaultProps } from '../bulk/__stubs__';
+
+jest.mock('react-redux', () => ({
+	...jest.requireActual('react-redux'),
+	useDispatch: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+describe.only('<Step1 />', () => {
+	test('should render component', () => {
+		const store = {
+			bulk: state,
+		};
+		const component = render(<Step1 {...defaultProps} />, { store });
+
+		expect(component.getByTestId('modal')).toBeInTheDocument();
+	});
+
+	test('should set isBulkMode to false when single file has been uploaded', () => {
+		const setBulkModeSpy = jest.spyOn(SliceModule, 'setBulkMode');
+		const store = {
+			bulk: {
+				...state,
+				files: [files[0]],
+			},
+			single: {},
+		};
+
+		render(<Step1 {...defaultProps} />, { store });
+
+		expect(setBulkModeSpy).toHaveBeenCalledWith(false);
+	});
+
+	test('should set isBulkMode to true when multiple have been uploaded', () => {
+		const setBulkModeSpy = jest.spyOn(SliceModule, 'setBulkMode');
+		const store = {
+			bulk: {
+				...state, // State stub has 2 files
+			},
+			single: {},
+		};
+
+		render(<Step1 {...defaultProps} />, { store });
+
+		expect(setBulkModeSpy).toHaveBeenCalledWith(true);
+	});
+
+	test('should set all fields to editable when isBulkMode is FALSE and metadataFields are provided', () => {
+		const setAllFieldsEditableSpy = jest.spyOn(SliceModule, 'setAllFieldsEditable');
+		const props = { ...defaultProps, metadataFields };
+		const store = {
+			bulk: {
+				...state,
+				isBulkMode: false,
+			},
+			single: {},
+		};
+
+		render(<Step1 {...props} />, { store });
+
+		expect(setAllFieldsEditableSpy).toHaveBeenCalled();
+	});
+
+	test('should reset all fields and files to default/initial when isBulkMode is TRUE and metadataFields are provided', () => {
+		const resetFieldsAndFilesSpy = jest.spyOn(SliceModule, 'resetFieldsAndFiles');
+		const props = { ...defaultProps, metadataFields };
+		const store = {
+			bulk: {
+				...state,
+				isBulkMode: true,
+			},
+			single: {},
+		};
+
+		render(<Step1 {...props} />, { store });
+
+		expect(resetFieldsAndFilesSpy).toHaveBeenCalled();
+	});
+});

--- a/src/features/bulk/steps/Step1.tsx
+++ b/src/features/bulk/steps/Step1.tsx
@@ -26,15 +26,16 @@ export default function Step1<T>(props: Step1Props<T>) {
 
 	useEffect(() => {
 		if (!metadataFields) return;
+
 		if (!fields?.length) dispatch(setFields(metadataFields));
 	}, [metadataFields, fields]);
 
 	useEffect(() => {
 		if (files && files.length !== 0) {
-			setIsValidForm(true);
-		} else {
-			setIsValidForm(false);
+			return setIsValidForm(true);
 		}
+
+		setIsValidForm(false);
 	}, [files]);
 
 	const handleFileRemove = React.useCallback(

--- a/src/features/bulk/steps/Step1.tsx
+++ b/src/features/bulk/steps/Step1.tsx
@@ -4,13 +4,13 @@ import { useAppDispatch, useAppSelector } from '../../hooks';
 
 import { CustomFileLight, CustomFileLightOrRejection } from '../../../types';
 import BulkWizard from '../wizard/BulkWizard';
-import { Props } from '../bulk/types';
+import { BulkUploadProps } from '../bulk/types';
 import { IBulkField } from '../bulk/store/model';
 import { getCustomFiles, getFields } from '../bulk/store/selectors';
 import { removeFile, setFields, setFile } from '../bulk/store/slice';
 import { Step1Styles } from './styles';
 
-export interface Step1Props<T> extends Props<T> {
+export interface Step1Props<T> extends BulkUploadProps<T> {
 	metadataFields?: IBulkField[];
 }
 
@@ -35,7 +35,7 @@ export default function Step1<T>(props: Step1Props<T>) {
 		} else {
 			setIsValidForm(false);
 		}
-	}, [files])
+	}, [files]);
 
 	const handleFileRemove = React.useCallback(
 		(file: CustomFileLightOrRejection) => {

--- a/src/features/bulk/steps/Step1.tsx
+++ b/src/features/bulk/steps/Step1.tsx
@@ -1,14 +1,24 @@
 import React, { useEffect, useState } from 'react';
 import { FileUpload, FileUploadProps } from '@amsterdam/bmi-component-library';
+
+import { getCustomFiles, getFields, getIsBulkMode } from '../bulk/store/selectors';
+
+import BulkWizard from '../wizard/BulkWizard';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 
-import { CustomFileLight, CustomFileLightOrRejection } from '../../../types';
-import BulkWizard from '../wizard/BulkWizard';
 import { BulkUploadProps } from '../bulk/types';
+import { CustomFileLight, CustomFileLightOrRejection } from '../../../types';
 import { IBulkField } from '../bulk/store/model';
-import { getCustomFiles, getFields } from '../bulk/store/selectors';
-import { removeFile, setFields, setFile } from '../bulk/store/slice';
 import { Step1Styles } from './styles';
+
+import {
+	removeFile,
+	resetFieldsAndFiles,
+	setAllFieldsEditable,
+	setBulkMode,
+	setFields,
+	setFile,
+} from '../bulk/store/slice';
 
 export interface Step1Props<T> extends BulkUploadProps<T> {
 	metadataFields?: IBulkField[];
@@ -23,20 +33,7 @@ export default function Step1<T>(props: Step1Props<T>) {
 
 	const files = useAppSelector(getCustomFiles);
 	const fields = useAppSelector(getFields);
-
-	useEffect(() => {
-		if (!metadataFields) return;
-
-		if (!fields?.length) dispatch(setFields(metadataFields));
-	}, [metadataFields, fields]);
-
-	useEffect(() => {
-		if (files && files.length !== 0) {
-			return setIsValidForm(true);
-		}
-
-		setIsValidForm(false);
-	}, [files]);
+	const isBulkMode = useAppSelector(getIsBulkMode);
 
 	const handleFileRemove = React.useCallback(
 		(file: CustomFileLightOrRejection) => {
@@ -59,6 +56,34 @@ export default function Step1<T>(props: Step1Props<T>) {
 		},
 		[onFileSuccess],
 	);
+
+	useEffect(() => {
+		if (!metadataFields) return;
+
+		if (!fields?.length) dispatch(setFields(metadataFields));
+	}, [metadataFields, fields]);
+
+	useEffect(() => {
+		if (files && files.length !== 0) {
+			return setIsValidForm(true);
+		}
+
+		setIsValidForm(false);
+	}, [files]);
+
+	useEffect(() => {
+		if (files && files.length) {
+			dispatch(setBulkMode(files.length > 1));
+		}
+	}, [files]);
+
+	// When changing mode from single to bulk or vice versa, we need set the default form state
+	useEffect(() => {
+		if (metadataFields) {
+			const reducer = isBulkMode ? resetFieldsAndFiles : setAllFieldsEditable;
+			dispatch(reducer(metadataFields));
+		}
+	}, [isBulkMode, metadataFields]);
 
 	return (
 		<BulkWizard {...props} isValidForm={isValidForm}>

--- a/src/features/bulk/steps/Step2.tsx
+++ b/src/features/bulk/steps/Step2.tsx
@@ -33,7 +33,6 @@ export default function Step2<T>(props: Step2Props<T>) {
 				dispatch(setFields(newFields));
 
 				// Filter metadata
-				//
 				// This filters obsolete metadata from files when changeIndividual is removed on the field.
 				newFields
 					.filter((field) => !field.changeIndividual)

--- a/src/features/bulk/steps/Step2.tsx
+++ b/src/features/bulk/steps/Step2.tsx
@@ -3,16 +3,18 @@ import { Navigate } from 'react-router-dom-v5-compat';
 import debounce from 'debounce';
 import { Heading } from '@amsterdam/asc-ui';
 
-import { MetadataGenericType } from '../../../types';
-import BulkMetadataForm from '../../../components/BulkMetadataForm/BulkMetadataForm';
-import { BulkStepsToRoutes, DEFAULT_DEBOUNCE } from '../bulk/constants';
 import { getFields, getFiles } from '../bulk/store/selectors';
 import { setFields, setFileMetadata } from '../bulk/store/slice';
-import { BulkUploadProps } from '../bulk/types';
+
 import BulkWizard from '../wizard/BulkWizard';
+import BulkMetadataForm from '../../../components/BulkMetadataForm/BulkMetadataForm';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { convertBulkFieldsToMetadataGenericTypes, identicalObjects, reduceFieldData } from '../bulk/utils';
 import { buildPath } from '../../../utils';
+import { BulkStepsToRoutes, DEFAULT_DEBOUNCE } from '../bulk/constants';
+
+import { MetadataGenericType } from '../../../types';
+import { BulkUploadProps } from '../bulk/types';
 
 export interface Step2Props<T> extends BulkUploadProps<T> {}
 

--- a/src/features/bulk/steps/Step2.tsx
+++ b/src/features/bulk/steps/Step2.tsx
@@ -8,13 +8,13 @@ import BulkMetadataForm from '../../../components/BulkMetadataForm/BulkMetadataF
 import { BulkStepsToRoutes, DEFAULT_DEBOUNCE } from '../bulk/constants';
 import { getFields, getFiles } from '../bulk/store/selectors';
 import { setFields, setFileMetadata } from '../bulk/store/slice';
-import { Props } from '../bulk/types';
+import { BulkUploadProps } from '../bulk/types';
 import BulkWizard from '../wizard/BulkWizard';
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { convertBulkFieldsToMetadataGenericTypes, identicalObjects, reduceFieldData } from '../bulk/utils';
 import { buildPath } from '../../../utils';
 
-export interface Step2Props<T> extends Props<T> {}
+export interface Step2Props<T> extends BulkUploadProps<T> {}
 
 export default function Step2<T>(props: Step2Props<T>) {
 	const { metadataForm, basePath } = props;

--- a/src/features/bulk/steps/Step3.tsx
+++ b/src/features/bulk/steps/Step3.tsx
@@ -1,31 +1,29 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Navigate } from 'react-router-dom-v5-compat';
 import { Heading } from '@amsterdam/asc-ui';
 
-import { MetadataGenericType } from '../../../types';
-import { useAppSelector } from '../../hooks';
-import FileViewer from '../FileViewer/FileViewer';
-
-import { BulkStepsToRoutes } from '../bulk/constants';
 import { getFiles, getIsBulkMode } from '../bulk/store/selectors';
-import { BulkUploadProps } from '../bulk/types';
+
 import BulkWizard from '../wizard/BulkWizard';
-import { StyledPaginationBottom, StyledPaginationTop } from './styles';
+import FileViewer from '../FileViewer/FileViewer';
 import { buildPath } from '../../../utils';
-import { useDispatch } from 'react-redux';
-import { setAllFieldsEditable } from '../bulk/store/slice';
+import { useAppSelector } from '../../hooks';
+
+import { MetadataGenericType } from '../../../types';
+import { BulkUploadProps } from '../bulk/types';
+import { BulkStepsToRoutes } from '../bulk/constants';
+import { StyledPaginationBottom, StyledPaginationTop } from './styles';
 
 const LABEL_NEXT = 'Volgende document';
 const LABEL_PREVIOUS = 'Vorige document';
 
 export default function Step3<T>(props: BulkUploadProps<T>) {
-	const { getDocumentViewUrl, basePath, metadataFields } = props;
+	const { getDocumentViewUrl, basePath } = props;
 
 	const [isValidForm, setIsValidForm] = useState<boolean>(false);
 	const [currentFileIndex, setCurrentFileIndex] = useState<number>(0);
 	const [currentPage, setCurrentPage] = useState<number>(1);
 
-	const dispatch = useDispatch();
 	const files = useAppSelector(getFiles);
 	const isBulkMode = useAppSelector(getIsBulkMode);
 
@@ -43,17 +41,11 @@ export default function Step3<T>(props: BulkUploadProps<T>) {
 		[files],
 	);
 
-	useEffect(() => {
-		if (!isBulkMode && metadataFields) {
-			dispatch(setAllFieldsEditable(metadataFields));
-		}
-	}, [isBulkMode, metadataFields]);
-
 	// Redirect to step1 when state is not correct
 	if (files?.length === 0) return <Navigate to={buildPath(basePath, BulkStepsToRoutes[1])} />;
 
 	return (
-		<BulkWizard {...props} isValidForm={isValidForm}>
+		<BulkWizard {...props} isValidForm={isValidForm} canShowErrorMessage={true}>
 			{showPaginationNav && (
 				<StyledPaginationTop
 					labelNext={LABEL_NEXT}

--- a/src/features/bulk/steps/Step3.tsx
+++ b/src/features/bulk/steps/Step3.tsx
@@ -8,7 +8,7 @@ import FileViewer from '../FileViewer/FileViewer';
 
 import { BulkStepsToRoutes } from '../bulk/constants';
 import { getFiles } from '../bulk/store/selectors';
-import { Props } from '../bulk/types';
+import { BulkUploadProps } from '../bulk/types';
 import BulkWizard from '../wizard/BulkWizard';
 import { StyledPaginationBottom, StyledPaginationTop } from './styles';
 import { buildPath } from '../../../utils';
@@ -16,7 +16,7 @@ import { buildPath } from '../../../utils';
 const LABEL_NEXT = 'Volgende document';
 const LABEL_PREVIOUS = 'Vorige document';
 
-export default function Step3<T>(props: Props<T>) {
+export default function Step3<T>(props: BulkUploadProps<T>) {
 	const { getDocumentViewUrl, basePath } = props;
 
 	const files = useAppSelector(getFiles);

--- a/src/features/bulk/steps/Step3.tsx
+++ b/src/features/bulk/steps/Step3.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Navigate } from 'react-router-dom-v5-compat';
 import { Heading } from '@amsterdam/asc-ui';
 
@@ -7,27 +7,34 @@ import { useAppSelector } from '../../hooks';
 import FileViewer from '../FileViewer/FileViewer';
 
 import { BulkStepsToRoutes } from '../bulk/constants';
-import { getFiles } from '../bulk/store/selectors';
+import { getFiles, getIsBulkMode } from '../bulk/store/selectors';
 import { BulkUploadProps } from '../bulk/types';
 import BulkWizard from '../wizard/BulkWizard';
 import { StyledPaginationBottom, StyledPaginationTop } from './styles';
 import { buildPath } from '../../../utils';
+import { useDispatch } from 'react-redux';
+import { setAllFieldsEditable } from '../bulk/store/slice';
 
 const LABEL_NEXT = 'Volgende document';
 const LABEL_PREVIOUS = 'Vorige document';
 
 export default function Step3<T>(props: BulkUploadProps<T>) {
-	const { getDocumentViewUrl, basePath } = props;
-
-	const files = useAppSelector(getFiles);
+	const { getDocumentViewUrl, basePath, metadataFields } = props;
 
 	const [isValidForm, setIsValidForm] = useState<boolean>(false);
 	const [currentFileIndex, setCurrentFileIndex] = useState<number>(0);
 	const [currentPage, setCurrentPage] = useState<number>(1);
 
+	const dispatch = useDispatch();
+	const files = useAppSelector(getFiles);
+	const isBulkMode = useAppSelector(getIsBulkMode);
+
+	const showPaginationNav = files && isBulkMode;
+
 	const handleOnFormChange = useCallback((data: MetadataGenericType, valid: boolean) => {
 		setIsValidForm(valid);
 	}, []);
+
 	const handleOnPageChange = useCallback(
 		(page: number) => {
 			setCurrentPage(page);
@@ -35,41 +42,46 @@ export default function Step3<T>(props: BulkUploadProps<T>) {
 		},
 		[files],
 	);
+
+	useEffect(() => {
+		if (!isBulkMode && metadataFields) {
+			dispatch(setAllFieldsEditable(metadataFields));
+		}
+	}, [isBulkMode, metadataFields]);
+
 	// Redirect to step1 when state is not correct
-	if (files?.length === 0) {
-		return <Navigate to={buildPath(basePath, BulkStepsToRoutes[1])} />;
-	} else {
-		return (
-			<BulkWizard {...props} isValidForm={isValidForm}>
-				{files && (
-					<StyledPaginationTop
-						labelNext={LABEL_NEXT}
-						labelPrevious={LABEL_PREVIOUS}
-						collectionSize={files.length}
-						pageSize={1}
-						page={currentPage}
-						onPageChange={handleOnPageChange}
-					/>
-				)}
-				<Heading forwardedAs="h2">Individueel metadateren</Heading>
-				{files && (
-					<FileViewer
-						file={files[currentFileIndex]}
-						getDocumentViewUrl={getDocumentViewUrl}
-						onChange={handleOnFormChange}
-					/>
-				)}
-				{files && (
-					<StyledPaginationBottom
-						labelNext={LABEL_NEXT}
-						labelPrevious={LABEL_PREVIOUS}
-						collectionSize={files.length}
-						pageSize={1}
-						page={currentPage}
-						onPageChange={handleOnPageChange}
-					/>
-				)}
-			</BulkWizard>
-		);
-	}
+	if (files?.length === 0) return <Navigate to={buildPath(basePath, BulkStepsToRoutes[1])} />;
+
+	return (
+		<BulkWizard {...props} isValidForm={isValidForm}>
+			{showPaginationNav && (
+				<StyledPaginationTop
+					labelNext={LABEL_NEXT}
+					labelPrevious={LABEL_PREVIOUS}
+					collectionSize={files.length}
+					pageSize={1}
+					page={currentPage}
+					onPageChange={handleOnPageChange}
+				/>
+			)}
+			<Heading forwardedAs="h2">Individueel metadateren</Heading>
+			{files && (
+				<FileViewer
+					file={files[currentFileIndex]}
+					getDocumentViewUrl={getDocumentViewUrl}
+					onChange={handleOnFormChange}
+				/>
+			)}
+			{showPaginationNav && (
+				<StyledPaginationBottom
+					labelNext={LABEL_NEXT}
+					labelPrevious={LABEL_PREVIOUS}
+					collectionSize={files.length}
+					pageSize={1}
+					page={currentPage}
+					onPageChange={handleOnPageChange}
+				/>
+			)}
+		</BulkWizard>
+	);
 }

--- a/src/features/bulk/wizard/BulkWizard.test.tsx
+++ b/src/features/bulk/wizard/BulkWizard.test.tsx
@@ -1,39 +1,12 @@
 import React from 'react';
 import { screen, fireEvent, act, waitFor } from '@testing-library/react';
-import { render } from '../../../tests/utils/testUtils';
-import { CurrentStep } from '../bulk/store/model';
-import { asset, state as mockState, mockData, schema, uischema } from '../bulk/__stubs__';
-import {
-	getDocumentViewUrlMock,
-	getHeadersMock,
-	getPostUrlMock,
-	onCancelMock,
-	onChangeMock,
-	onFileRemoveMock,
-	onFileSuccessMock,
-	onMetadataSubmitMock,
-} from '../bulk/__mocks__/bulk';
-import BulkWizard from './BulkWizard';
 
-const defaultProps = {
-	asset: asset,
-	getPostUrl: getPostUrlMock,
-	getHeaders: getHeadersMock,
-	getDocumentViewUrl: getDocumentViewUrlMock,
-	onFileSuccess: onFileSuccessMock,
-	onFileRemove: onFileRemoveMock,
-	metadataForm: {
-		schema,
-		uischema,
-		data: mockData,
-		onChange: onChangeMock,
-		renderers: [],
-	},
-	onMetadataSubmit: onMetadataSubmitMock,
-	onCancel: onCancelMock,
-	basePath: '/',
-	isValidForm: false,
-};
+import BulkWizard from './BulkWizard';
+import { CurrentStep } from '../bulk/store/model';
+
+import { render } from '../../../tests/utils/testUtils';
+import { state as mockState, defaultProps } from '../bulk/__stubs__';
+import { onCancelMock, onMetadataSubmitMock } from '../bulk/__mocks__/bulk';
 
 afterEach(() => {
 	jest.restoreAllMocks();

--- a/src/features/bulk/wizard/BulkWizard.tsx
+++ b/src/features/bulk/wizard/BulkWizard.tsx
@@ -60,7 +60,7 @@ export default function BulkWizard<T>({
 	const handleNext = useCallback(() => {
 		dispatch(setBulkMode(files.length > 1));
 		dispatch(stepForward({ navigate }));
-	}, [navigate]);
+	}, [navigate, files]);
 
 	const resetAndClose = useCallback(() => {
 		dispatch(resetState({ navigate }));

--- a/src/features/bulk/wizard/BulkWizard.tsx
+++ b/src/features/bulk/wizard/BulkWizard.tsx
@@ -129,12 +129,12 @@ export default function BulkWizard<T>({
 			<ModalStyle
 				id="dms-upload-wizard"
 				open
-				onClose={() => setConfirmTermination()}
+				onClose={files.length > 0 ? () => setConfirmTermination() : undefined}
 				closeOnBackdropClick={false}
 				size="xl"
 				classnames="modal--bulk"
 			>
-				<Modal.TopBar hideCloseButton={false} onCloseButton={() => setConfirmTermination()}>
+				<Modal.TopBar hideCloseButton={false} onCloseButton={() => setConfirmTermination(files.length === 0)}>
 					<ModalTopBarStyle styleAs="h4" as="h2">
 						Bestanden uploaden voor {asset.code} ({asset.name})
 					</ModalTopBarStyle>
@@ -154,7 +154,7 @@ export default function BulkWizard<T>({
 					</Modal.Content>
 				</>
 				<WizardFooter
-					cancel={{ visible: true, onClick: setConfirmTermination, dataTestId: 'cancel-wizard' }}
+					cancel={{ visible: true, onClick: () => setConfirmTermination(), dataTestId: 'cancel-wizard' }}
 					previous={{
 						visible: currentStep > CurrentStep.Upload,
 						onClick: handlePrev,

--- a/src/features/bulk/wizard/BulkWizard.tsx
+++ b/src/features/bulk/wizard/BulkWizard.tsx
@@ -9,7 +9,7 @@ import WizardFooter from '../../../components/WizardFooter/WizardFooter';
 
 import { useAppDispatch, useAppSelector } from '../../hooks';
 import { CurrentStep, IBulkFile, IBulkState } from '../bulk/store/model';
-import { Props } from '../bulk/types';
+import { BulkUploadProps } from '../bulk/types';
 import { getChangeIndividualFields, getCurrentStep, getFiles, getState } from '../bulk/store/selectors';
 import { resetState, stepBack, stepForward } from '../bulk/store/slice';
 
@@ -21,7 +21,7 @@ import { useSelector } from 'react-redux';
 type BulkWizardProps<T> = {
 	children?: React.ReactNode;
 	isValidForm: boolean;
-} & Props<T>;
+} & BulkUploadProps<T>;
 
 const makeMetadataObject = (state: IBulkState): IBulkFile[] => {
 	return state.files.map((file) => ({

--- a/src/features/bulk/wizard/BulkWizard.tsx
+++ b/src/features/bulk/wizard/BulkWizard.tsx
@@ -90,12 +90,8 @@ export default function BulkWizard<T>({
 		}, []);
 	};
 
-	const filesContainingInvalidMetadata = () => {
-		return files.filter((file) => file.isMetadataValid === false);
-	};
-
-	const filesHaveInvalidMetadata = () => {
-		return hasValues(filesContainingInvalidMetadata());
+	const filesHaveInvalidMetadata = (): boolean => {
+		return files.filter((file) => file.isMetadataValid === false).length > 0;
 	};
 
 	const handleSubmit = useCallback(

--- a/src/features/bulk/wizard/BulkWizard.tsx
+++ b/src/features/bulk/wizard/BulkWizard.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch, useAppSelector } from '../../hooks';
 import { CurrentStep, IBulkFile, IBulkState } from '../bulk/store/model';
 import { BulkUploadProps } from '../bulk/types';
 import { getChangeIndividualFields, getCurrentStep, getFiles, getState } from '../bulk/store/selectors';
-import { resetState, stepBack, stepForward } from '../bulk/store/slice';
+import { resetState, setBulkMode, stepBack, stepForward } from '../bulk/store/slice';
 
 import { AlertStyle, ModalContentStyle, ModalStyle, ModalTopBarStyle } from './styles';
 import { convertBulkFieldsToBulkFileMetadata, reduceMetadata } from '../bulk/utils';
@@ -38,22 +38,27 @@ export default function BulkWizard<T>({
 	onCancel,
 	onMetadataSubmit,
 }: BulkWizardProps<T>) {
+	const dispatch = useAppDispatch();
+
 	const state = useAppSelector(getState);
+	const currentStep = useSelector(getCurrentStep);
+	const files = useSelector(getFiles);
+
+	const individualFields = useSelector(getChangeIndividualFields);
+
+	const navigate = useNavigate();
+
 	const { isOpen: isConfirmTerminationOpen, confirm: setConfirmTermination } = useConfirmTermination(() =>
 		resetAndClose(),
 	);
 	const { isOpen: isConfirmSaveOpen } = useConfirmSave(() => save());
-	const currentStep = useSelector(getCurrentStep);
-	const dispatch = useAppDispatch();
-	const files = useSelector(getFiles);
-	const individualFields = useSelector(getChangeIndividualFields);
-	const navigate = useNavigate();
 
 	const handlePrev = useCallback(() => {
 		dispatch(stepBack({ navigate }));
 	}, [navigate]);
 
 	const handleNext = useCallback(() => {
+		dispatch(setBulkMode(files.length > 1));
 		dispatch(stepForward({ navigate }));
 	}, [navigate]);
 

--- a/src/features/single/wizard/SingleWizard.tsx
+++ b/src/features/single/wizard/SingleWizard.tsx
@@ -70,8 +70,8 @@ export default function SingleWizard<T>({
 	return (
 		<>
 			{isOpen && <ConfirmTermination backdropOpacity={1} />}
-			<Modal id="dms-upload-wizard" open onClose={() => confirm()} closeOnBackdropClick={false}>
-				<Modal.TopBar hideCloseButton={false} onCloseButton={() => confirm()}>
+			<Modal id="dms-upload-wizard" open onClose={!file ? undefined : () => confirm()} closeOnBackdropClick={false}>
+				<Modal.TopBar hideCloseButton={false} onCloseButton={() => confirm(!file)}>
 					<ModalTopBarStyle styleAs="h4" as="h2">
 						Bestand uploaden voor {asset.name}
 					</ModalTopBarStyle>
@@ -82,7 +82,7 @@ export default function SingleWizard<T>({
 					</Modal.Content>
 				</>
 				<WizardFooter
-					cancel={{ visible: true, onClick: confirm, dataTestId: 'cancel-wizard' }}
+					cancel={{ visible: true, onClick: () => confirm(), dataTestId: 'cancel-wizard' }}
 					previous={{
 						visible: currentStep >= CurrentStep.SelectFields,
 						onClick: handlePrev,

--- a/src/hooks/useConfirmTermination.tsx
+++ b/src/hooks/useConfirmTermination.tsx
@@ -2,7 +2,10 @@ import { useState, useCallback } from 'react';
 import { confirm as dialogConfirm } from '@amsterdam/bmi-component-library';
 import { customSubject } from '../components/ConfirmTermination/ConfirmTermination';
 
-function useConfirmTermination(onTerminate: () => void): { isOpen: boolean; confirm: (forceClose?: boolean) => void } {
+function useConfirmTermination(onTerminate: () => void): {
+	isOpen: boolean;
+	confirm: (forceTerminate?: boolean) => void;
+} {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
 	const confirm = useCallback((forceClose?: boolean) => {
 		if (typeof forceClose !== 'undefined' && forceClose) {

--- a/src/hooks/useConfirmTermination.tsx
+++ b/src/hooks/useConfirmTermination.tsx
@@ -2,9 +2,13 @@ import { useState, useCallback } from 'react';
 import { confirm as dialogConfirm } from '@amsterdam/bmi-component-library';
 import { customSubject } from '../components/ConfirmTermination/ConfirmTermination';
 
-function useConfirmTermination(onTerminate: () => void): { isOpen: boolean; confirm: () => void } {
+function useConfirmTermination(onTerminate: () => void): { isOpen: boolean; confirm: (forceClose?: boolean) => void } {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
-	const confirm = useCallback(() => {
+	const confirm = useCallback((forceClose?: boolean) => {
+		if (typeof forceClose !== 'undefined' && forceClose) {
+			return onTerminate();
+		}
+
 		setIsOpen(true);
 		dialogConfirm(
 			{

--- a/src/hooks/useConfirmTermination.tsx
+++ b/src/hooks/useConfirmTermination.tsx
@@ -7,8 +7,8 @@ function useConfirmTermination(onTerminate: () => void): {
 	confirm: (forceTerminate?: boolean) => void;
 } {
 	const [isOpen, setIsOpen] = useState<boolean>(false);
-	const confirm = useCallback((forceClose?: boolean) => {
-		if (typeof forceClose !== 'undefined' && forceClose) {
+	const confirm = useCallback((forceTerminate?: boolean) => {
+		if (typeof forceTerminate !== 'undefined' && forceTerminate) {
 			return onTerminate();
 		}
 

--- a/src/hooks/useConfirmTerminiation.test.tsx
+++ b/src/hooks/useConfirmTerminiation.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
-import useConfirmTermination from './useConfirmTermination';
 import { act } from 'react-dom/test-utils';
+
+import useConfirmTermination from './useConfirmTermination';
 
 describe('useConfirmTermination()', () => {
 	test('should render is open as true and return callback', () => {
@@ -12,5 +13,38 @@ describe('useConfirmTermination()', () => {
 
 		expect(result.current.isOpen).toBe(true);
 		expect(result.current.confirm).toEqual(expect.any(Function));
+	});
+
+	test('should call terminate callback when forceTerminate is true', () => {
+		const terminateCallback = jest.fn();
+		const { result } = renderHook(() => useConfirmTermination(terminateCallback));
+
+		act(() => {
+			result.current.confirm(true);
+		});
+
+		expect(terminateCallback).toHaveBeenCalled();
+	});
+
+	test('should not call terminate callback when forceTerminate is false', () => {
+		const terminateCallback = jest.fn();
+		const { result } = renderHook(() => useConfirmTermination(terminateCallback));
+
+		act(() => {
+			result.current.confirm(false);
+		});
+
+		expect(terminateCallback).not.toHaveBeenCalled();
+	});
+
+	test('should not call terminate callback when forceTerminate is undefined', () => {
+		const terminateCallback = jest.fn();
+		const { result } = renderHook(() => useConfirmTermination(terminateCallback));
+
+		act(() => {
+			result.current.confirm();
+		});
+
+		expect(terminateCallback).not.toHaveBeenCalled();
 	});
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { default as SingleUpload } from './features/single/single/Single';
 export { Props as SingleUploadProps, MetadataDataSubmitCallbackArg } from './features/single/single/types';
 export { default as BulkUpload } from './features/bulk/bulk/Bulk';
-export { Props as BulkUploadProps } from './features/bulk/bulk/types';
+export { BulkUploadProps } from './features/bulk/bulk/types';
 
 export { RowLayoutSchema, CustomJsonSchema, CustomFileLight, CancelCallbackArg } from './types';
 export { IBulkField } from './features/bulk/bulk/store/model';

--- a/src/tests/utils/testUtils.tsx
+++ b/src/tests/utils/testUtils.tsx
@@ -35,7 +35,6 @@ interface StoreOverrides {
 		currentStep?: CurrentStepBulk;
 		files?: IBulkFile[];
 		fields?: IBulkField[];
-		selectedFileId?: IBulkField;
 	};
 }
 

--- a/src/tests/utils/testUtils.tsx
+++ b/src/tests/utils/testUtils.tsx
@@ -35,6 +35,7 @@ interface StoreOverrides {
 		currentStep?: CurrentStepBulk;
 		files?: IBulkFile[];
 		fields?: IBulkField[];
+		isBulkMode?: boolean;
 	};
 }
 


### PR DESCRIPTION
First idea was to have only one upload component instead two which we have currently. For now decided to keep the separate components because the impact and risk would be too much this update.
The new functionality is build on top of the current setup to keep it simple for now.

Done:
- Adding a state property `isBulkMode`, to keep track of bulk or single-bulk mode.
- On files change, setting the isBulkmode
- On files change, (re-)setting the default/initial form fields for bulk or single-bulk mode.
- Skip the second step when single-bulk mode
- Only show cancel upload warning when files are added otherwise immediate close upload
- Updated and added new tests